### PR TITLE
User/bduhbya/fix_Windows_unit_test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,11 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# VIM ignores
+*.swp
+*.swo
+*~
+
+# Project specific ignores
+UNIT_TEST_LOGS/*

--- a/Tracing_test.py
+++ b/Tracing_test.py
@@ -29,16 +29,7 @@ LOG_TEST_DATA = [{
 }]
 
 
-def get_file_content():
-  try:
-    with open(TEST_LOG_FILE, "r") as file:
-      content = file.read()
-      return content
-  except Exception as e:
-    print(f"An error occurred: {e}")
-
-
-def get_file_content_2(fileName):
+def get_file_content(fileName):
   try:
     with open(fileName, "r") as file:
       content = file.read()
@@ -66,7 +57,7 @@ def log_and_verify_file(traceFun, type, shouldLog, method):
   line = LOG_TEST_DATA[type].get('LOG_LINE')
   lineType = LOG_TEST_DATA[type].get('LINE_TYPE')
   traceFun(line)
-  content = get_file_content_2(fileName)
+  content = get_file_content(fileName)
   assert log_contains(
     line, content) == shouldLog, f"Expected {line} in log to be {shouldLog}"
   assert log_contains(
@@ -74,24 +65,7 @@ def log_and_verify_file(traceFun, type, shouldLog, method):
     content) == shouldLog, f"Expected {lineType} in log to be {shouldLog}"
 
 
-def log_and_verify(traceFun, type, shouldLog):
-  line = LOG_TEST_DATA[type].get('LOG_LINE')
-  lineType = LOG_TEST_DATA[type].get('LINE_TYPE')
-  traceFun(line)
-  content = get_file_content()
-  assert log_contains(
-    line, content) == shouldLog, f"Expected {line} in log to be {shouldLog}"
-  assert log_contains(
-    lineType,
-    content) == shouldLog, f"Expected {lineType} in log to be {shouldLog}"
-
-
-def check_line_count(logFile, count):
-  actual = count_lines(logFile)
-  assert actual == count, f"Expected {count} lines in {logFile}, found {actual}"
-
-
-def check_line_count_2(method, count):
+def check_line_count(method, count):
   fileName = get_log_name(method)
   actual = count_lines(fileName)
   assert actual == count, f"Expected {count} lines in {fileName}, found {actual}"
@@ -142,49 +116,49 @@ def tracing_test_setup():
 def test_debug_logging():
   tracer = get_logger_and_clean_previous(test_debug_logging, LOG_LEVEL_DEBUG)
   log_and_verify_file(tracer.debug, DEBUG, True, test_debug_logging)
-  check_line_count_2(test_debug_logging, 1)
+  check_line_count(test_debug_logging, 1)
   log_and_verify_file(tracer.info, INFO, True, test_debug_logging)
-  check_line_count_2(test_debug_logging, 2)
+  check_line_count(test_debug_logging, 2)
   log_and_verify_file(tracer.warning, WARNING, True, test_debug_logging)
-  check_line_count_2(test_debug_logging, 3)
+  check_line_count(test_debug_logging, 3)
   log_and_verify_file(tracer.error, ERROR, True, test_debug_logging)
-  check_line_count_2(test_debug_logging, 4)
+  check_line_count(test_debug_logging, 4)
 
 
 def test_info_logging():
-  tracer = LogTrace(TEST_LOGGER, TEST_LOG_FILE, LOG_LEVEL_INFO)
-  log_and_verify(tracer.debug, DEBUG, False)
-  check_line_count(TEST_LOG_FILE, 0)
-  log_and_verify(tracer.info, INFO, True)
-  check_line_count(TEST_LOG_FILE, 1)
-  log_and_verify(tracer.warning, WARNING, True)
-  check_line_count(TEST_LOG_FILE, 2)
-  log_and_verify(tracer.error, ERROR, True)
-  check_line_count(TEST_LOG_FILE, 3)
+  tracer = get_logger_and_clean_previous(test_info_logging, LOG_LEVEL_INFO)
+  log_and_verify_file(tracer.debug, DEBUG, False, test_info_logging)
+  check_line_count(test_info_logging, 0)
+  log_and_verify_file(tracer.info, INFO, True, test_info_logging)
+  check_line_count(test_info_logging, 1)
+  log_and_verify_file(tracer.warning, WARNING, True, test_info_logging)
+  check_line_count(test_info_logging, 2)
+  log_and_verify_file(tracer.error, ERROR, True, test_info_logging)
+  check_line_count(test_info_logging, 3)
 
 
 def test_warn_logging():
-  tracer = LogTrace(TEST_LOGGER, TEST_LOG_FILE, LOG_LEVEL_WARNING)
-  log_and_verify(tracer.debug, DEBUG, False)
-  check_line_count(TEST_LOG_FILE, 0)
-  log_and_verify(tracer.info, INFO, False)
-  check_line_count(TEST_LOG_FILE, 0)
-  log_and_verify(tracer.warning, WARNING, True)
-  check_line_count(TEST_LOG_FILE, 1)
-  log_and_verify(tracer.error, ERROR, True)
-  check_line_count(TEST_LOG_FILE, 2)
+  tracer = get_logger_and_clean_previous(test_warn_logging, LOG_LEVEL_WARNING)
+  log_and_verify_file(tracer.debug, DEBUG, False, test_warn_logging)
+  check_line_count(test_warn_logging, 0)
+  log_and_verify_file(tracer.info, INFO, False, test_warn_logging)
+  check_line_count(test_warn_logging, 0)
+  log_and_verify_file(tracer.warning, WARNING, True, test_warn_logging)
+  check_line_count(test_warn_logging, 1)
+  log_and_verify_file(tracer.error, ERROR, True, test_warn_logging)
+  check_line_count(test_warn_logging, 2)
 
 
 def test_error_logging():
-  tracer = LogTrace(TEST_LOGGER, TEST_LOG_FILE, LOG_LEVEL_ERROR)
-  log_and_verify(tracer.debug, DEBUG, False)
-  check_line_count(TEST_LOG_FILE, 0)
-  log_and_verify(tracer.info, INFO, False)
-  check_line_count(TEST_LOG_FILE, 0)
-  log_and_verify(tracer.warning, WARNING, False)
-  check_line_count(TEST_LOG_FILE, 0)
-  log_and_verify(tracer.error, ERROR, True)
-  check_line_count(TEST_LOG_FILE, 1)
+  tracer = get_logger_and_clean_previous(test_error_logging, LOG_LEVEL_ERROR)
+  log_and_verify_file(tracer.debug, DEBUG, False, test_error_logging)
+  check_line_count(test_error_logging, 0)
+  log_and_verify_file(tracer.info, INFO, False, test_error_logging)
+  check_line_count(test_error_logging, 0)
+  log_and_verify_file(tracer.warning, WARNING, False, test_error_logging)
+  check_line_count(test_error_logging, 0)
+  log_and_verify_file(tracer.error, ERROR, True, test_error_logging)
+  check_line_count(test_error_logging, 1)
 
 
 def test_empty_logger_name():

--- a/Tracing_test.py
+++ b/Tracing_test.py
@@ -50,7 +50,6 @@ def count_lines(file_path):
 
 def get_log_name(method):
   return os.path.join(TEST_LOG_DIR, method.__name__ + TEST_LOG_FILE_POSTFIX)
-  #Path(TEST_LOG_DIR) / method.__name__ + TEST_LOG_FILE_POSTFIX
 
 def log_and_verify_file(traceFun, type, shouldLog, method):
   fileName = get_log_name(method)
@@ -162,14 +161,16 @@ def test_error_logging():
 
 
 def test_empty_logger_name():
-  tracer = LogTrace('', TEST_LOG_FILE, LOG_LEVEL_ERROR)
-  file_path = Path(TEST_LOG_FILE)
+  logger_name = get_log_name(test_empty_logger_name)
+  tracer = LogTrace('', logger_name, LOG_LEVEL_ERROR)
+  file_path = Path(logger_name)
   assert file_path.exists() == True, f"Expected file {TEST_LOG_FILE} to exist"
 
 
 def test_none_logger_name():
-  tracer = LogTrace(None, TEST_LOG_FILE, LOG_LEVEL_ERROR)
-  file_path = Path(TEST_LOG_FILE)
+  logger_name = get_log_name(test_none_logger_name)
+  tracer = LogTrace(None, logger_name, LOG_LEVEL_ERROR)
+  file_path = Path(logger_name)
   assert file_path.exists() == True, f"Expected file {TEST_LOG_FILE} to exist"
 
 

--- a/Tracing_test.py
+++ b/Tracing_test.py
@@ -1,9 +1,8 @@
 import platform
 import pytest
 from Tracing import LogTrace, LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, LOG_LEVEL_WARNING, LOG_LEVEL_ERROR
-import os
 from pathlib import Path
-from Unit_test_common import get_test_log_file_name
+from Unit_test_common import get_test_log_file_name, clear_test_file
 
 
 TEST_LOGGER = 'test_logger'
@@ -81,17 +80,9 @@ def verify_assert_and_no_tracing(expectedAssert, testLogger, logFile, level, log
 
 
 
-def clear_test_file(name):
-  try:
-    os.remove(name)
-    print(f"clear_test_file, Removed previous test file: {name}")
-  except OSError as e:
-    print(f"clear_test_file, Error deleting file  {name}: {type(e).__name__} - {str(e)}")
-
-
 def get_logger_and_clean_previous(method, logLevel):
   fileName = get_log_name(method)
-  clear_test_file(fileName)
+  clear_test_file(fileName, f"{__name__} - {method}")
   return LogTrace(method, fileName, logLevel)
 
 

--- a/Tracing_test.py
+++ b/Tracing_test.py
@@ -1,3 +1,4 @@
+import platform
 import pytest
 from Tracing import LogTrace, LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, LOG_LEVEL_WARNING, LOG_LEVEL_ERROR
 import os
@@ -175,7 +176,12 @@ def test_none_logger_name():
 
 
 def test_empty_file_name():
-  verify_assert_and_no_tracing(IsADirectoryError, TEST_LOGGER, '',
+  expected_assert = None
+  if platform.system() == "Windows":
+    expected_assert = PermissionError
+  else:
+    expected_assert = IsADirectoryError
+  verify_assert_and_no_tracing(expected_assert, TEST_LOGGER, '',
                                LOG_LEVEL_ERROR)
 
 

--- a/Tracing_test.py
+++ b/Tracing_test.py
@@ -3,6 +3,9 @@ from Tracing import LogTrace, LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, LOG_LEVEL_WARNING
 import os
 from pathlib import Path
 
+
+TEST_LOG_DIR = 'UNIT_TEST_LOGS'
+TEST_LOG_FILE_POSTFIX = '_test_log_file.txt'
 TEST_LOG_FILE = 'test_log_file.txt'
 TEST_LOGGER = 'test_logger'
 
@@ -10,6 +13,7 @@ ERROR = 0
 WARNING = 1
 INFO = 2
 DEBUG = 3
+
 LOG_TEST_DATA = [{
   'LOG_LINE': 'error log trace',
   'LINE_TYPE': '| ERROR |'
@@ -53,8 +57,12 @@ def count_lines(file_path):
   return line_count
 
 
+def get_log_name(method):
+  return os.path.join(TEST_LOG_DIR, method.__name__ + TEST_LOG_FILE_POSTFIX)
+  #Path(TEST_LOG_DIR) / method.__name__ + TEST_LOG_FILE_POSTFIX
+
 def log_and_verify_file(traceFun, type, shouldLog, method):
-  fileName = method.__name__ + "_" + TEST_LOG_FILE
+  fileName = get_log_name(method)
   line = LOG_TEST_DATA[type].get('LOG_LINE')
   lineType = LOG_TEST_DATA[type].get('LINE_TYPE')
   traceFun(line)
@@ -84,9 +92,9 @@ def check_line_count(logFile, count):
 
 
 def check_line_count_2(method, count):
-  logFile = method.__name__ + "_" + TEST_LOG_FILE
-  actual = count_lines(logFile)
-  assert actual == count, f"Expected {count} lines in {logFile}, found {actual}"
+  fileName = get_log_name(method)
+  actual = count_lines(fileName)
+  assert actual == count, f"Expected {count} lines in {fileName}, found {actual}"
 
 
 def verify_assert_and_no_tracing(expectedAssert, testLogger, logFile, level):
@@ -110,7 +118,7 @@ def clear_test_file(name):
 
 
 def get_logger_and_clean_previous(method, logLevel):
-  fileName = method.__name__ + "_" + TEST_LOG_FILE
+  fileName = get_log_name(method)
   clear_test_file(fileName)
   return LogTrace(method, fileName, logLevel)
 

--- a/Unit_test_common.py
+++ b/Unit_test_common.py
@@ -1,0 +1,8 @@
+import os
+
+TEST_LOG_DIR = 'UNIT_TEST_LOGS'
+TEST_LOG_FILE_POSTFIX = '_log_file.txt'
+
+def get_test_log_file_name(prefix: str):
+  return os.path.join(TEST_LOG_DIR, prefix + TEST_LOG_FILE_POSTFIX)
+

--- a/Unit_test_common.py
+++ b/Unit_test_common.py
@@ -6,3 +6,10 @@ TEST_LOG_FILE_POSTFIX = '_log_file.txt'
 def get_test_log_file_name(prefix: str):
   return os.path.join(TEST_LOG_DIR, prefix + TEST_LOG_FILE_POSTFIX)
 
+
+def clear_test_file(name, reason: str):
+  try:
+    print(f"clear_test_file for {reason}, Removing previous test file: {name}")
+    os.remove(name)
+  except OSError as e:
+    print(f"clear_test_file for {reason}, Error deleting file  {name}: {type(e).__name__} - {str(e)}")

--- a/Utility_test.py
+++ b/Utility_test.py
@@ -1,21 +1,13 @@
 import Utility
 import pytest
 import Tracing
-import os
-from Unit_test_common import get_test_log_file_name
+from Unit_test_common import get_test_log_file_name, clear_test_file
 
 UTIL_LOGGING = 'utility_test'
 UTIL_LOGGING_FILE = get_test_log_file_name(UTIL_LOGGING)
 TRACE_LEVEL = Tracing.LOG_LEVEL_DEBUG
 
 test_tracer = None
-
-def clear_test_file():
-  try:
-    os.remove(UTIL_LOGGING_FILE)
-    print(f"clear_test_file, Removed previous test file: {UTIL_LOGGING_FILE}")
-  except OSError as e:
-    print(f"clear_test_file, Error deleting file  {UTIL_LOGGING_FILE}: {type(e).__name__} - {str(e)}")
 
 def setup_logging():
   global test_tracer
@@ -46,7 +38,7 @@ def verify_gen_type_result(input, expected):
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_module():
-  clear_test_file()
+  clear_test_file(UTIL_LOGGING_FILE, f"{__name__} - setup_module")
 
 
 @pytest.fixture(autouse=True)

--- a/Utility_test.py
+++ b/Utility_test.py
@@ -2,9 +2,10 @@ import Utility
 import pytest
 import Tracing
 import os
+from Unit_test_common import get_test_log_file_name
 
 UTIL_LOGGING = 'utility_test'
-UTIL_LOGGING_FILE = UTIL_LOGGING + '_log_file.txt'
+UTIL_LOGGING_FILE = get_test_log_file_name(UTIL_LOGGING)
 TRACE_LEVEL = Tracing.LOG_LEVEL_DEBUG
 
 test_tracer = None


### PR DESCRIPTION
Update tracing module unit tests to run properly on Windows

Running the unit test for the tracing module on Windows results in file access errors when trying to use the same file for each test.

Update the tracing test module to use a unique file for each test. This also has the added benefit/side effect of leaving a better test record in the tracing.

Create a single utility for managing file creation and deletion for unit tests. Additionally, put the unit test output into a dedicated folder. Update the ignore file to ignore intermediate Python and them and the unit test output directory.

Re-factor the utility test module to take advantage of the common unit test methods